### PR TITLE
Fix infinite recursion in logger utilities

### DIFF
--- a/smarttrack.html
+++ b/smarttrack.html
@@ -8544,30 +8544,30 @@
             
             log: function(message, ...args) {
                 if (this.enabled) {
-                    Logger.log(`[SmartTrack] ${message}`, ...args);
+                    console.log(`[SmartTrack] ${message}`, ...args);
                 }
             },
             
             warn: function(message, ...args) {
                 if (this.enabled) {
-                    Logger.warn(`[SmartTrack] ${message}`, ...args);
+                    console.warn(`[SmartTrack] ${message}`, ...args);
                 }
             },
             
             error: function(message, ...args) {
                 // Les erreurs sont toujours affichées
-                Logger.error(`[SmartTrack] ${message}`, ...args);
+                console.error(`[SmartTrack] ${message}`, ...args);
             },
             
             debug: function(message, ...args) {
                 if (this.enabled) {
-                    Logger.debug(`[SmartTrack] ${message}`, ...args);
+                    console.debug(`[SmartTrack] ${message}`, ...args);
                 }
             },
             
             info: function(message, ...args) {
                 if (this.enabled) {
-                    Logger.info(`[SmartTrack] ${message}`, ...args);
+                    console.info(`[SmartTrack] ${message}`, ...args);
                 }
             }
         };

--- a/sw.js
+++ b/sw.js
@@ -13,19 +13,19 @@ const swLogger = {
   
   log: function(message, ...args) {
     if (this.enabled) {
-      swLogger.log(`[SmartTrack SW] ${message}`, ...args);
+      console.log(`[SmartTrack SW] ${message}`, ...args);
     }
   },
   
   warn: function(message, ...args) {
     if (this.enabled) {
-      swLogger.warn(`[SmartTrack SW] ${message}`, ...args);
+      console.warn(`[SmartTrack SW] ${message}`, ...args);
     }
   },
   
   error: function(message, ...args) {
     // Les erreurs sont toujours affichées
-    swLogger.error(`[SmartTrack SW] ${message}`, ...args);
+    console.error(`[SmartTrack SW] ${message}`, ...args);
   }
 };
 


### PR DESCRIPTION
Fix infinite recursion in custom `Logger` and `swLogger` utilities to prevent stack overflow errors.