### PR TITLE
Résoudre les problèmes d'accès aux modules

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -97,6 +97,8 @@ class SmartTrackApp {
         if (typeof Router !== 'undefined') {
             this.modules.router = Router;
             await Router.init();
+            // Exposer le router globalement après son initialisation
+            window.router = Router;
             console.log('✓ Router initialisé');
         }
         

--- a/assets/js/core/storage.js
+++ b/assets/js/core/storage.js
@@ -486,7 +486,10 @@ const Storage = (function() {
         clear,
         hasUnsavedChanges: hasChanges,
         getStats,
-        getStorageSize
+        getStorageSize,
+        // Alias pour compatibilité avec d'anciens appels
+        getItem: get,
+        setItem: set
     };
 })();
 


### PR DESCRIPTION
Fix application stuck on loading page and navigation issues after modularization.

The application was stuck because `Storage.getItem`/`setItem` calls failed after the module API changed to `Storage.get`/`set`. Additionally, the global `router` was not correctly exposed after its initialization, leading to navigation failures.