### PR TITLE
Fix application loading issue

### DIFF
--- a/assets/js/modules/exercises/exercises.model.js
+++ b/assets/js/modules/exercises/exercises.model.js
@@ -5,7 +5,7 @@
 
 const ExercisesModel = (function() {
     let exercises = [];
-    let isLoaded = false;
+    let loaded = false;
 
     /**
      * Initialiser le modèle
@@ -37,7 +37,7 @@ const ExercisesModel = (function() {
         try {
             const data = await Storage.get(STORAGE_KEYS.EXERCISES);
             exercises = data || [];
-            isLoaded = true;
+            loaded = true;
             
             // Émettre événement de chargement
             if (typeof EventBus !== 'undefined') {
@@ -77,7 +77,7 @@ const ExercisesModel = (function() {
      * Obtenir tous les exercices
      */
     function getAll() {
-        if (!isLoaded) {
+        if (!loaded) {
             console.warn('⚠️ Exercices non chargés, retour d\'un tableau vide');
             return [];
         }
@@ -504,7 +504,7 @@ const ExercisesModel = (function() {
      * Vérifier si les exercices sont chargés
      */
     function isLoaded() {
-        return isLoaded;
+        return loaded;
     }
 
     /**


### PR DESCRIPTION
Rename `isLoaded` variable to `loaded` to resolve a duplicate identifier error.

This duplicate declaration of `isLoaded` (as both a variable and a function) in `exercises.model.js` caused a JavaScript error, preventing the application from loading.