### PR TITLE
Vérifier l'accès à l'application

### DIFF
--- a/assets/js/core/router.js
+++ b/assets/js/core/router.js
@@ -133,16 +133,22 @@ const Router = (function() {
     function setupGuards() {
         // Garde pour les séances live
         guard(ROUTES.LIVE_SESSION, () => {
-            // Vérifier qu'une séance est en cours
+            // Vérifier qu'une séance au statut "active" existe
             return Storage.get(STORAGE_KEYS.SESSIONS)
                 .then(sessions => {
-                    const hasActivSession = sessions && sessions.some(s => s.isActive);
-                    if (!hasActivSession) {
+                    const hasActiveSession = Array.isArray(sessions) && sessions.some(s => s.status === 'active');
+
+                    if (!hasActiveSession) {
                         console.warn('⚠️ Tentative d\'accès à une séance live sans session active');
                         navigate(ROUTES.PREPARATION);
                         return false;
                     }
+
                     return true;
+                })
+                .catch(err => {
+                    console.error('❌ Erreur vérification session active :', err);
+                    return false;
                 });
         });
     }

--- a/assets/js/core/router.js
+++ b/assets/js/core/router.js
@@ -321,7 +321,18 @@ const Router = (function() {
 
             // Afficher l'écran correspondant
             const screenId = getScreenId(path);
-            const screen = document.getElementById(screenId);
+            let screen = document.getElementById(screenId);
+
+            // Rechercher d'abord par ID, puis en fallback par classe
+            if (!screen) {
+                screen = document.querySelector(`.${path}-screen`);
+
+                // Si on le trouve, on lui ajoute l'ID standard pour les prochaines navigations
+                if (screen) {
+                    screen.id = screenId;
+                }
+            }
+
             if (screen) {
                 screen.classList.add('active');
             } else {


### PR DESCRIPTION
<!-- Correct router logic to restore application access after modular update. -->

<!-- The modular update introduced two issues preventing application access:
1.  Screen display: The router expected `id="screen-route"` but views used `class="route-screen"`, causing screens to remain hidden. The fix adds a fallback to find screens by class and assign the correct ID.
2.  Live session guard: The guard incorrectly checked for a non-existent `isActive` property on session objects instead of the `status === 'active'` property, leading to erroneous redirects to the preparation screen. This has been corrected. -->