### PR TITLE
Analyse and adapt critical app files

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "SmartTrack - Suivi Intelligent d'Entraînement",
   "short_name": "SmartTrack",
   "description": "Application de suivi d'entraînement avec élastiques SmartWorkout",
-  "start_url": "./index.html",
+  "start_url": "./smarttrack.html",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#F2F2F7",

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,11 @@
 // SmartTrack Service Worker - Version intelligente
-const VERSION = '1.0.0';
+const VERSION = '1.0.1';
 const CACHE_NAME = `smarttrack-v${VERSION}`;
 const urlsToCache = [
   './smarttrack.html',
   './manifest.json',
-  './smarttrack-icon.png'
+  './smarttrack-icon.png',
+  'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.min.js'
 ];
 
 // Système de logging conditionnel pour Service Worker


### PR DESCRIPTION
Align PWA manifest and service worker with `smarttrack.html` to fix offline functionality and PWA launch.

The `start_url` in `manifest.json` was pointing to `index.html` which is not the application's entry point, leading to a blank page on PWA launch. Additionally, `sw.js` was not caching the Chart.js library, causing the application to break when launched offline without a prior network fetch of the library. These changes ensure the PWA is fully functional offline and launches correctly.